### PR TITLE
fix branch cloning whole chat

### DIFF
--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -58,7 +58,11 @@ export function ChatMessages({
   const messages = data?.page ?? [];
 
   const navigate = useNavigate();
-  const { mutate: createBranch, isPending: isCreatingBranch } = useMutation({
+  const {
+    mutate: createBranch,
+    isPending: isCreatingBranch,
+    variables: branchVariables,
+  } = useMutation({
     mutationFn: useConvexMutation(api.chats.mutations.branchChat),
 
     onSuccess: (newChatId?: string) => {
@@ -96,12 +100,16 @@ export function ChatMessages({
                 <ChatMessage
                   message={message}
                   isLastMessage={index === messages.length - 1}
-                  isBranching={isCreatingBranch}
+                  isBranching={
+                    isCreatingBranch &&
+                    branchVariables?.messageId === message._id
+                  }
                   onBranch={() => {
                     if (!isCreatingBranch) {
                       createBranch({
                         chatId: chatId as Id<'chats'>,
                         model: message.model,
+                        messageId: message._id,
                       });
                       return;
                     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to explicitly select a reference message when cloning or branching chats, providing more control over which messages are included in the new chat.
- **Improvements**
	- Branching a chat now visually indicates the specific message being branched from, rather than showing a global pending state.
- **Bug Fixes**
	- Ensured that only messages up to and including the selected reference message are copied when cloning or branching a chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->